### PR TITLE
Clarify "Unknown Shell" Error Message

### DIFF
--- a/commands/alias.go
+++ b/commands/alias.go
@@ -36,7 +36,7 @@ func alias(command *Command, args *Args) {
 	}
 
 	if shell == "" {
-		utils.Check(fmt.Errorf("Unknown shell"))
+		utils.Check(fmt.Errorf("Unknown shell: Set the SHELL enviornment variable or execute 'hub alies -s <shell name>'"))
 	}
 
 	shells := []string{"bash", "zsh", "sh", "ksh", "csh", "tcsh", "fish"}


### PR DESCRIPTION
In instances where the `SHELL` environment variable is not set, nor is the `-s` parameter set it is not clear what action should occur.  Clarify the error message to make it obvious.

Closes #1065

Untested.
